### PR TITLE
Properly define singleton `getInstance` method as static

### DIFF
--- a/src/mailmojo-plugin.php
+++ b/src/mailmojo-plugin.php
@@ -44,7 +44,7 @@ class MailMojoPlugin {
 	/**
 	 * Return the one and only singleton instance of this class.
 	 */
-	public function getInstance () {
+	public static function getInstance () {
 		if (empty(self::$instance)) {
 			self::$instance = new MailMojoPlugin();
 		}


### PR DESCRIPTION
Defines the `MailMojoPlugin::getInstance` method correctly as static according to its usage, which also gets rid of PHP 5 Strict warnings.