### PR TITLE
Use paragraph for description in widget output

### DIFF
--- a/src/mailmojo-widget.php
+++ b/src/mailmojo-widget.php
@@ -199,7 +199,7 @@ HTML;
 
 		// Description
 		if (!empty($instance['desc'])) {
-			$desc = "<h2>{$instance['desc']}</h2>";
+			$desc = "<p>{$instance['desc']}</p>";
 		}
 
 		// The main output of the widget


### PR DESCRIPTION
The widget currently uses a level 2 header for description, which is not very appropriate for normally medium long descriptions. This change proposes to use a simple paragraph instead.