### PR TITLE
Support WordPress not being hosted on root of domain

### DIFF
--- a/src/js/mailmojo.js
+++ b/src/js/mailmojo.js
@@ -29,7 +29,9 @@ jQuery(document).ready(function () {
 			$notice = $container.find('.notice');
 
 		jQuery(this).submit(function (e) {
-			var $this = jQuery(this);
+			var
+				$this = jQuery(this),
+				url = window.location.toString();
 
 			e.preventDefault();
 
@@ -55,7 +57,7 @@ jQuery(document).ready(function () {
 				}
 			}
 
-			jQuery.post('/', $this.serializeArray(), function (data, resStatus) {
+			jQuery.post(url, $this.serializeArray(), function (data, resStatus) {
 				if (resStatus == 'success') {
 					$loader.hide();
 					if (data.success) {


### PR DESCRIPTION
The AJAX submit functionality assumed WordPress was hosted on the root of the domain, by always sending data to '/'. This is an assumption this plugin should not make.

This switches to using the current document URL instead, same as the normal HTML form does with a blank `action` attribute.