### PR TITLE
Clean up plugin code

### DIFF
--- a/src/mailmojo-plugin.php
+++ b/src/mailmojo-plugin.php
@@ -1,43 +1,32 @@
 <?php
-/*  Copyright Eliksir AS  (email : post@e5r.no)
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+/*
+ * Copyright Eliksir AS  (email : post@e5r.no)
+ * License: GPLv2 <http://www.gnu.org/licenses/gpl-2.0.html>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 class MailMojoPlugin {
 	/*
 	 * The singleton instance
 	 */
 	private static $instance;
 
-	/*
-	 * MailMojo username
-	 */
-	public $username;
-
 	/**
 	 * Initiates the plugin.
 	 */
 	private function __construct () {
-		add_action('admin_init', array($this, 'registerSettings'));
-		add_action('admin_menu', array($this, 'initSettingsPage'));
-
 		$this->initWidget();
-
-		$options = $this->getOptions();
-		$this->username = !empty($options['username']) ? $options['username'] : '';
-
-		// Init localization for the plugin
 		$this->loadTextDomain();
 	}
 
@@ -48,42 +37,18 @@ class MailMojoPlugin {
 		if (empty(self::$instance)) {
 			self::$instance = new MailMojoPlugin();
 		}
+
 		return self::$instance;
 	}
 
 	/**
-	 * Adds mailmojo_options to the database when activating this plugin. The widget
-	 * options will automatically be created when used the first time.
+	 * Return true if plugin is fully activated.
+	 *
+	 * @return bool
 	 */
-	public static function setUpOptions () {
-		add_option('mailmojo_options', '', '', 'no');
-	}
-
-	/**
-	 * Removes all database options for MailMojo widget.
-	 */
-	public static function removeOptions () {
-		delete_option('mailmojo_options');
-		// Since we know our widget is named mailmojo we can safely remove it.
-		delete_option('widget_mailmojo');
-	}
-
-	/**
-	 * Register mailmojo_options so that POST action in admin
-	 * will save our options.
-	 */
-	public function registerSettings () {
-		register_setting('mailmojo_options', 'mailmojo_options');
-	}
-
-	/**
-	 * Adds the MailMojo settings page as sub menu to settings.
-	 */
-	public function initSettingsPage () {
-		add_submenu_page(
-			'options-general.php', 'MailMojo', 'MailMojo',
-			'activate_plugins', __FILE__, array($this, 'adminPage')
-		);
+	public function isActive () {
+		$options = get_option('mailmojo_options');
+		return !empty($options['username']);
 	}
 
 	/**
@@ -104,62 +69,23 @@ class MailMojoPlugin {
 	}
 
 	/**
-	 * Output the content for the MailMojo settings page.
-	 */
-	public function adminPage () {
-		$output = <<<HTML
-<div class="wrap">
-	<div id="icon-options-general" class="icon32"><br /></div>
-	<h2>%s</h2>
-HTML;
-		echo sprintf($output, __('MailMojo Settings', 'mailmojo'));
-		if (function_exists('curl_init')) {
-			echo '<p>' . __('Enter the username of the MailMojo account where the mailing list you want signups to are located. After saving the changes, go to the Widgets menu in the Appearance section to configure your widget.', 'mailmojo') . '</p>';
-			echo '<form action="options.php" method="post">';
-			settings_fields('mailmojo_options');
-			$output = <<<HTML
-			<table class="form-table">
-				<tr valign="top">
-					<th scope="row">
-						<label for="mailmojo-username">%s</label>
-					</th>
-					<td>
-						<input name="mailmojo_options[username]" type="text"
-							id="mailmojo-username" value="{$this->username}"
-							class="regular-text code" />
-					</td>
-				</tr>
-			</table>
-			<p class="submit">
-				<input type="submit" name="Submit" class="button-primary" value="%s" />
-			</p>
-		</form>
-	</div>
-HTML;
-			echo sprintf($output,
-					__('Username', 'mailmojo'),
-					__('Save Changes', 'mailmojo')
-			);
-		}
-		else {
-			echo '<p>' . __('You need to have the PHP Client URL Library (cURL) to be able to use this widget. You can read up on how to install the extension <a href="http://php.net/manual/en/book.curl.php">here</a>', 'mailmojo') . '</p>';
-		}
-	}
-
-	/**
-	 * Returns the basename of the plugin. Relative to the wp-content/plugins/ directory.
-	 */
-	public function getBasename () {
-		return plugin_basename(__FILE__);
-	}
-
-	/**
-	 * Returns the options for MailMojo. Since we store our option serialized,
-	 * this is returned as an array with out options as keys.
+	 * Return URL for the settings page.
 	 *
-	 * @return array
+	 * @return string
 	 */
-	public function getOptions () {
-		return get_option('mailmojo_options');
+	public function getSettingsPageUrl () {
+		global $blog_id;
+		$adminUrl = get_admin_url($blog_id);
+		return "{$adminUrl}options-general.php?page={MailMojoSettings::MENU_SLUG}";
+	}
+
+	/**
+	 * Returns username stored as an option if it exist.
+	 *
+	 * @return string
+	 */
+	public function getUsername () {
+		$options = get_option('mailmojo_options');
+		return !empty($options['username']) ? $options['username'] : '';
 	}
 }

--- a/src/mailmojo-settings.php
+++ b/src/mailmojo-settings.php
@@ -1,0 +1,134 @@
+<?php
+/*
+ * Copyright Eliksir AS  (email : post@e5r.no)
+ * License: GPLv2 <http://www.gnu.org/licenses/gpl-2.0.html>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+class MailMojoSettings {
+	const GROUP_NAME = 'mailmojo-widget-settings';
+	const MENU_SLUG = 'mailmojo-widget';
+	const MENU_TITLE = 'MailMojo';
+	const PAGE_TITLE = 'MailMojo';
+
+	/*
+	 * The singleton instance
+	 */
+	private static $instance;
+
+	/**
+	 * Initiates the settings.
+	 */
+	public function __construct () {
+		add_action('admin_menu', array($this, 'addPluginPage'));
+		add_action('admin_init', array($this, 'pageInit'));
+		$this->options = get_option('mailmojo_options');
+	}
+
+	/**
+	 * Return the one and only singleton instance of this class.
+	 */
+	public static function getInstance () {
+		if (empty(self::$instance)) {
+			self::$instance = new MailMojoSettings();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Add plugins page.
+	 */
+	public function addPluginPage () {
+		add_options_page(
+			self::PAGE_TITLE,
+			self::MENU_TITLE,
+			'manage_options',
+			self::MENU_SLUG,
+			array($this, 'create_admin_page')
+		);
+	}
+
+	/**
+	 * Initiate the settings page.
+	 */
+	public function pageInit () {
+		register_setting(
+			self::GROUP_NAME,
+			'mailmojo_options',
+			array($this, 'sanitize')
+		);
+
+		add_settings_section(
+			'mailmojo_settings_id',
+			'Settings',
+			array($this, 'settingsSection'),
+			'mailmojo-settings-admin'
+		);
+
+		add_settings_field(
+			'username',
+			'Username',
+			array($this, 'usernameField'),
+			'mailmojo-settings-admin',
+			'mailmojo_settings_id'
+		);
+	}
+
+	/**
+	 * Remove settings from database.
+	 */
+	public function removeSettings () {
+		unregister_setting(self::GROUP_NAME, 'mailmojo_options');
+	}
+
+	/**
+	 * Hook for printing the admin page for the settings.
+	 */
+	public function create_admin_page () {
+		include('templates/settings.php');
+	}
+
+	/**
+	 * Output section for settings.
+	 */
+	public function settingsSection () {
+		print('Enter the username of your MailMojo Account.');
+	}
+
+	/**
+	 * Output settings field for username.
+	 */
+	public function usernameField () {
+		printf(
+			'<input type="text" id="username" name="mailmojo_options[username]" ' .
+			'value="%s">',
+			isset($this->options['username']) ?
+				esc_attr($this->options['username']) : ''
+		);
+	}
+
+	/**
+	 * Sanitize the settings field before saving it.
+	 */
+	public function sanitize ($input) {
+		$new_input = array();
+
+		foreach ($input as $key => $value) {
+			$new_input[$key] = sanitize_text_field($value);
+		}
+
+		return $new_input;
+	}
+}

--- a/src/mailmojo-widget.php
+++ b/src/mailmojo-widget.php
@@ -1,24 +1,26 @@
 <?php
-/*  Copyright Eliksir AS  (email : post@e5r.no)
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
+/*
+ * Copyright Eliksir AS  (email : post@e5r.no)
+ * License: GPLv2 <http://www.gnu.org/licenses/gpl-2.0.html>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 class MailMojoWidget extends WP_Widget {
 	/*
 	 * MailMojoPlugin
 	 */
-	private $mmPlugin;
+	private $plugin;
 
 	/**
 	 * Inits the widget, script, styles and subscribe action.
@@ -29,8 +31,10 @@ class MailMojoWidget extends WP_Widget {
 		);
 		parent::__construct('mailmojo', __('MailMojo Signup Form', 'mailmojo'), $options);
 
-		$this->mmPlugin = MailMojoPlugin::getInstance();
 		add_action('init', array($this, 'initFiles'));
+		add_action('parse_request', array($this, 'subscribe'));
+
+		$this->plugin = MailMojoPlugin::getInstance();
 	}
 
 	/**
@@ -49,10 +53,9 @@ class MailMojoWidget extends WP_Widget {
 	 * @param array $instance
 	 */
 	public function form ($instance) {
-		if (empty($this->mmPlugin->username)) {
-			global $blog_id;
-			$adminUrl = get_admin_url($blog_id);
-			$url = "{$adminUrl}options-general.php?page={$this->mmPlugin->getBasename()}";
+		if (!$this->plugin->isActive()) {
+			$url = $this->plugin->getSettingsPageUrl();
+
 			echo '<p>' . sprintf(
 				__('You need to enter your MailMojo account information on the <a href="%s">MailMojo settings page</a>', 'mailmojo'),
 				$url) . '</p>';
@@ -68,65 +71,11 @@ class MailMojoWidget extends WP_Widget {
 			'tags' => '',
 			'buttontext' => __('Sign me up!', 'mailmojo'),
 		);
-		$vars = wp_parse_args($instance, $defaults);
-		extract($vars);
 
-		$incname = checked($incname, true, false);
-		$output = <<<HTML
-<h3>%s</h3>
-<p>
-	<label for="{$this->get_field_id('listid')}">%s:</label>
-	<input class="widefat" type="text" id="{$this->get_field_id('listid')}"
-			name="{$this->get_field_name('listid')}" value="{$listid}">
-	<br/>
-	<small>%s</small>
-</p>
-<p>
-	<label for="{$this->get_field_id('title')}">%s:</label>
-	<input class="widefat" type="text" id="{$this->get_field_id('title')}"
-			name="{$this->get_field_name('title')}" value="{$title}">
-</p>
-<p>
-	<label for="{$this->get_field_id('desc')}">%s:</label>
-	<textarea class="widefat" id="{$this->get_field_id('desc')}"
-			name="{$this->get_field_name('desc')}">{$desc}</textarea>
-</p>
-<p>
-	<label for="{$this->get_field_id('incname')}">
-		<input type="checkbox" id="{$this->get_field_id('incname')}"
-			name="{$this->get_field_name('incname')}" {$incname}>
-		%s
-	</label>
-</p>
-<p>
-	<label for="{$this->get_field_id('buttontext')}">%s:</label>
-	<input class="widefat" type="text" id="{$this->get_field_id('buttontext')}"
-			name="{$this->get_field_name('buttontext')}" value="{$buttontext}">
-</p>
-<h3>%s</h3>
-<p>
-	<label for="{$this->get_field_id('tagdesc')}">%s:</label>
-	<input class="widefat" type="text" id="{$this->get_field_id('tagdesc')}"
-			name="{$this->get_field_name('tagdesc')}" value="{$tagdesc}">
-</p>
-<p>
-	<label for="{$this->get_field_id('tags')}">%s:</label>
-	<textarea class="widefat" id="{$this->get_field_id('tags')}"
-			name="{$this->get_field_name('tags')}">{$tags}</textarea>
-</p>
-HTML;
-		echo sprintf($output,
-			__('General', 'mailmojo'),
-			__('MailMojo List ID', 'mailmojo'),
-			__('To find the list ID: Go to the email list of your choice in MailMojo, and look at the last part of the URL. That is the list ID. E.g. given "mailmojo.no/lists/123", 123 is the list ID.', 'mailmojo'),
-			__('Title', 'mailmojo'),
-			__('Description Below Title', 'mailmojo'),
-			__('Include name field', 'mailmojo'),
-			__('Signup Button Text', 'mailmojo'),
-			__('Optional Tags', 'mailmojo'),
-			__('Tag Selection Label', 'mailmojo'),
-			__('Tags (comma separated)', 'mailmojo')
-		);
+		$instance = wp_parse_args($instance, $defaults);
+		$instance['incname'] = checked($instance['incname'], true, false);
+
+		include('templates/widget-admin.php');
 	}
 
 	/**
@@ -151,55 +100,15 @@ HTML;
 	 * @param array $instance
 	 */
 	public function widget ($args, $instance) {
-		$incname = $tags = $desc = '';
-		extract($args);
-
-		if (empty($this->mmPlugin->username) || empty($instance['listid'])) {
+		if (!$this->plugin->isActive() || empty($instance['listid'])) {
 			return '';
 		}
 
-		// Include name input field
-		if ($instance['incname']) {
-			$incname = <<<HTML
-<p class="field">
-	<label for="mailmojo_{$this->number}_name">%s:</label>
-	<input class="text" type="text" id="mailmojo_{$this->number}_name" name="name">
-</p>
-HTML;
-			$incname = sprintf($incname, __('Name', 'mailmojo'));
-		}
-
-		$tags = '';
 		if (!empty($instance['tags'])) {
-			$tags = $this->getHtmlForTags($instance);
+			$instance['tags'] = explode(',', $instance['tags']);
 		}
 
-		$desc = '';
-		if (!empty($instance['desc'])) {
-			$desc = "<p>{$instance['desc']}</p>";
-		}
-
-		// The main output of the widget
-		$output = <<<HTML
-{$before_widget}
-	{$before_title}{$instance['title']}{$after_title}
-	$desc
-	<form method="post" action="{$this->getSubscribeUrl($instance['listid'])}"
-			id="mailmojo_{$this->number}_form"
-			class="mailmojo_form">
-		<p class="field">
-			<label for="mailmojo_{$this->number}_email">%s:</label>
-			<input class="text" type="text" id="mailmojo_{$this->number}_email" name="email">
-		</p>
-		$incname
-		$tags
-		<p class="submit">
-			<input class="submit" type="submit" value="{$instance['buttontext']}">
-		</p>
-	</form>
-{$after_widget}
-HTML;
-		echo sprintf($output, __('E-mail', 'mailmojo'));
+		include('templates/widget-page.php');
 	}
 
 	/**
@@ -209,36 +118,7 @@ HTML;
 	 * @return string
 	 */
 	private function getSubscribeUrl ($listid) {
-		return "https://{$this->mmPlugin->username}.mailmojo.no/{$listid}/s";
-	}
-
-	/**
-	 * Returns the HTML for checkboxes with tags.
-	 *
-	 * @param $instance
-	 * @return string
-	 */
-	private function getHtmlForTags ($instance) {
-		$output = '';
-		if (!empty($instance['tags'])) {
-			if (!empty($instance['tagdesc'])) {
-				$output .= "<p>{$instance['tagdesc']}:</p>\n";
-			}
-			$tags = explode(',', $instance['tags']);
-			$output .= "<ul class=\"field\">\n";
-			foreach ($tags as $tag) {
-				$t = ucfirst(mb_strtolower(trim($tag)));
-				$output .= <<<HTML
-<li>
-	<label>
-		<input type="checkbox" name="tags[]" value="{$tag}" />
-		{$t}
-	</label>
-</li>
-HTML;
-			}
-			$output .= "</ul>\n";
-		}
-		return $output;
+		$username = $this->plugin->getUsername();
+		return "https://{$username}.mailmojo.no/{$listid}/s";
 	}
 }

--- a/src/mailmojo.php
+++ b/src/mailmojo.php
@@ -9,28 +9,29 @@ Version: 0.7
 */
 
 /*
- * Copyright Eliksir AS <http://e5r.no>
+ * Copyright Eliksir AS  (email : post@e5r.no)
  * License: GPLv2 <http://www.gnu.org/licenses/gpl-2.0.html>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2, as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
 include('mailmojo-plugin.php');
+include('mailmojo-settings.php');
 include('mailmojo-widget.php');
 
-// Inits the plugin and widget.
-$mm = MailMojoPlugin::getInstance();
+// Sets up plugin, settings and widget
+MailMojoPlugin::getInstance();
+MailMojoSettings::getInstance();
 
-// Register hooks for the plugin.
-register_activation_hook(__FILE__, array('MailMojoPlugin', 'setUpOptions'));
-register_uninstall_hook( __FILE__, array('MailMojoPlugin', 'removeOptions'));
+register_uninstall_hook(__FILE__, array('MailMojoSettings', 'removeSettings'));

--- a/src/templates/settings.php
+++ b/src/templates/settings.php
@@ -1,0 +1,10 @@
+<div class="wrap">
+	<h1>MailMojo Settings</h1>
+	<form method="post" action="options.php">
+	<?php
+		settings_fields('mailmojo-widget-settings');
+		do_settings_sections('mailmojo-settings-admin');
+		submit_button();
+	?>
+	</form>
+</div>

--- a/src/templates/widget-admin.php
+++ b/src/templates/widget-admin.php
@@ -1,0 +1,75 @@
+<h3><?php echo __('General', 'mailmojo') ?></h3>
+<p>
+	<label for="<?php echo $this->get_field_id('listid') ?>">
+		<?php echo __('MailMojo List ID', 'mailmojo') ?>:
+	</label>
+	<input class="widefat" type="text"
+		id="<?php echo $this->get_field_id('listid') ?>"
+		name="<?php echo $this->get_field_name('listid') ?>"
+		value="<?php echo $instance['listid'] ?>">
+	<br/>
+	<small>
+		<?php echo __('To find the list ID: Go to the email list of your choice in MailMojo,
+		and look at the last part of the URL. That is the list ID. E.g. given
+		"mailmojo.no/lists/123", 123 is the list ID.', 'mailmojo') ?>
+	</small>
+</p>
+
+<p>
+	<label for="<?php echo $this->get_field_id('title') ?>">
+		<?php echo __('Title', 'mailmojo') ?>:
+	</label>
+	<input class="widefat" type="text"
+			id="<?php echo $this->get_field_id('title') ?>"
+			name="<?php echo $this->get_field_name('title') ?>"
+			value="<?php echo $instance['title'] ?>">
+</p>
+
+<p>
+	<label for="<?php echo $this->get_field_id('desc') ?>">
+		<?php echo __('Description Below Title', 'mailmojo') ?>:
+	</label>
+	<textarea class="widefat"
+			id="<?php echo $this->get_field_id('desc') ?>"
+			name="<?php echo $this->get_field_name('desc') ?>"><?php echo $instance['desc'] ?></textarea>
+</p>
+
+<p>
+	<label for="<?php echo $this->get_field_id('incname') ?>">
+		<input type="checkbox"
+			id="<?php echo $this->get_field_id('incname') ?>"
+			name="<?php echo $this->get_field_name('incname') ?>"
+			<?php echo $instance['incname'] ?>>
+		<?php echo __('Include name field', 'mailmojo') ?>
+	</label>
+</p>
+
+<p>
+	<label for="<?php echo $this->get_field_id('buttontext') ?>">
+		<?php echo __('Signup Button Text', 'mailmojo') ?>:
+	</label>
+	<input class="widefat" type="text"
+			id="<?php echo $this->get_field_id('buttontext') ?>"
+			name="<?php echo $this->get_field_name('buttontext') ?>"
+			value="<?php echo $instance['buttontext'] ?>">
+</p>
+
+<h3><?php echo __('Optional Tags', 'mailmojo') ?></h3>
+<p>
+	<label for="<?php echo $this->get_field_id('tagdesc') ?>">
+		<?php echo __('Tag Selection Label', 'mailmojo') ?>:
+	</label>
+	<input class="widefat" type="text"
+		id="<?php echo $this->get_field_id('tagdesc') ?>"
+		name="<?php echo $this->get_field_name('tagdesc') ?>"
+		value="<?php echo $instance['tagdesc'] ?>">
+</p>
+
+<p>
+	<label for="<?php echo $this->get_field_id('tags') ?>">
+		<?php echo __('Tags (comma separated)', 'mailmojo') ?>:
+	</label>
+	<textarea class="widefat"
+			id="<?php echo $this->get_field_id('tags') ?>"
+			name="<?php echo $this->get_field_name('tags') ?>"><?php echo $instance['tags'] ?></textarea>
+</p>

--- a/src/templates/widget-page.php
+++ b/src/templates/widget-page.php
@@ -1,0 +1,56 @@
+<?php echo $args['before_widget'] ?>
+
+<?php echo $args['before_title'] ?>
+	<?php echo $instance['title'] ?>
+<?php echo $args['after_title'] ?>
+
+<?php if (!empty($instance['desc'])) : ?>
+	<p><?php echo $instance['desc'] ?></p>
+<?php endif; ?>
+
+<form method="post"
+	action="<?php echo $this->getSubscribeUrl($instance['listid']) ?>"
+	id="mailmojo_<?php echo $this->number ?>_form"
+	class="mailmojo_form">
+
+	<p class="field">
+		<label for="mailmojo_<?php echo $this->number ?>_email">
+			<?php echo __('E-mail', 'mailmojo') ?>:
+		</label>
+		<input class="text" type="text"
+			id="mailmojo_<?php echo $this->number ?>_email"
+			name="email">
+	</p>
+
+	<?php if (!empty($instance['incname'])) : ?>
+		<p class="field">
+			<label for="mailmojo_<?php echo $this->number ?>_name">
+				<?php echo __('Name', 'mailmojo') ?>:
+			</label>
+			<input class="text" type="text"
+				id="mailmojo_<?php echo $this->number ?>_name"
+				name="name">
+		</p>
+	<?php endif; ?>
+
+	<?php if (!empty($instance['tags'])) : ?>
+		<p><?php echo $instance['tagdesc'] ?>:</p>
+		<ul class="field">
+			<?php foreach ($instance['tags'] as $tag) : ?>
+				<?php $t = ucfirst(mb_strtolower(trim($tag))); ?>
+				<li>
+					<label>
+						<input type="checkbox" name="tags[]" value="<?php echo $tag ?>" />
+						 <?php echo $t ?>
+					</label>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+	<?php endif; ?>
+
+	<p class="submit">
+		<input class="submit" type="submit" value="<?php echo $instance['buttontext'] ?>">
+	</p>
+</form>
+
+<?php echo $args['after_widget'] ?>


### PR DESCRIPTION
- Move most of the HTML code to their own template files.
- Remove the usage of `extract` function. It's bad practice to expose
  all variables.
- Use Settings API, which makes it easier to extend on it in the future.