### PR TITLE
Display site-wide notice when access token is missing

### DIFF
--- a/src/mailmojo-plugin.php
+++ b/src/mailmojo-plugin.php
@@ -36,6 +36,9 @@ class MailMojoPlugin {
 		if ($accessToken) {
 			MailMojo\Configuration::getDefaultConfiguration()->setAccessToken($accessToken);
 		}
+		else {
+			add_action('admin_notices', array($this, 'displayNoticeInfo'));
+		}
 	}
 
 	/**
@@ -47,6 +50,19 @@ class MailMojoPlugin {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Display a site-wide notice on missing settings for the widget.
+	 *
+	 * For users that have upgraded from v0.x to v1 the signup form will still
+	 * work but we want them to add an access token instead.
+	 */
+	public function displayNoticeInfo () {
+		echo '<br><div class="update-nag">' . sprintf(
+			__('Settings for the MailMojo widget is outdated. <a href="%s">Please update the settings now</a>.', 'mailmojo'),
+			$this->getSettingsPageUrl()
+		) . '</div>';
 	}
 
 	/**

--- a/src/mailmojo.php
+++ b/src/mailmojo.php
@@ -33,4 +33,5 @@ include_once('mailmojo-widget.php');
 
 MailMojoPlugin::getInstance();
 
+
 register_uninstall_hook(__FILE__, array('MailMojoSettings', 'removeSettings'));


### PR DESCRIPTION
We want users that recently have upgraded to v1 to really update the
settings for the widget. Meaning that we want them to add an access
token. By presenting this site-wide message we should hopefully get them
to do it.