### PR TITLE
Support for single vs multiple tags and fixed tags

### DIFF
--- a/src/mailmojo-widget.php
+++ b/src/mailmojo-widget.php
@@ -105,8 +105,10 @@ class MailMojoWidget extends WP_Widget {
 			'title' => __('Newsletter Signup', 'mailmojo'),
 			'desc' => '',
 			'incname' => false,
-			'tagdesc' => __('Interests', 'mailmojo'),
+			'tagdesc' => __('Interests:', 'mailmojo'),
+			'tagtype' => 'multiple',
 			'tags' => '',
+			'fixedtags' => '',
 			'buttontext' => __('Sign me up!', 'mailmojo'),
 		);
 

--- a/src/templates/widget-admin.php
+++ b/src/templates/widget-admin.php
@@ -48,15 +48,35 @@
 	</label>
 </p>
 
-<h4><?php echo __('Optional Tags', 'mailmojo') ?></h4>
+<h4>
+	<?php echo __('Selectable tags', 'mailmojo') ?>
+	<small>(<?php echo __('optional', 'mailmojo') ?>)</small>
+</h4>
 <p>
 	<label for="<?php echo $this->get_field_id('tagdesc') ?>">
-		<?php echo __('Tag Selection Label', 'mailmojo') ?>:
+		<?php echo __('Tag selection label', 'mailmojo') ?>:
 	</label>
 	<input class="widefat" type="text"
 		id="<?php echo $this->get_field_id('tagdesc') ?>"
 		name="<?php echo $this->get_field_name('tagdesc') ?>"
 		value="<?php echo $instance['tagdesc'] ?>">
+</p>
+<p>
+	<label><?php echo __('Type', 'mailmojo') ?>:</label><br/>
+	<label>
+		<input class="widefat" type="radio"
+			name="<?php echo $this->get_field_name('tagtype') ?>"
+			value="single"
+			<?php echo $instance['tagtype'] == 'single' ? 'checked': '' ?>>
+		<?php echo __('Single choice', 'mailmojo') ?>
+	</label><br/>
+	<label>
+		<input class="widefat" type="radio"
+			name="<?php echo $this->get_field_name('tagtype') ?>"
+			value="multiple"
+			<?php echo $instance['tagtype'] == 'multiple' ? 'checked': '' ?>>
+		<?php echo __('Multiple choice', 'mailmojo') ?>
+	</label>
 </p>
 <p>
 	<label for="<?php echo $this->get_field_id('tags') ?>">
@@ -65,4 +85,19 @@
 	<textarea class="widefat"
 			id="<?php echo $this->get_field_id('tags') ?>"
 			name="<?php echo $this->get_field_name('tags') ?>"><?php echo $instance['tags'] ?></textarea>
+</p>
+
+
+<h4>
+	<?php echo __('Fixed tag(s)', 'mailmojo') ?>
+	<small>(<?php echo __('optional', 'mailmojo') ?>)</small>
+</h4>
+<p><em><?php echo __('These tags will automatically be added to the subscribed contact.', 'mailmojo') ?></em></p>
+<p>
+	<label for="<?php echo $this->get_field_id('fixedtags') ?>">
+		<?php echo __('Tags (comma separated)', 'mailmojo') ?>:
+	</label>
+	<textarea class="widefat"
+			id="<?php echo $this->get_field_id('fixedtags') ?>"
+			name="<?php echo $this->get_field_name('fixedtags') ?>"><?php echo $instance['fixedtags'] ?></textarea>
 </p>

--- a/src/templates/widget-page.php
+++ b/src/templates/widget-page.php
@@ -34,14 +34,17 @@
 	<?php endif; ?>
 
 	<?php if (!empty($instance['tags'])) : ?>
-		<p><?php echo $instance['tagdesc'] ?>:</p>
+		<?php if (!empty($instance['tagdesc'])) : ?>
+			<p><?php echo $instance['tagdesc'] ?></p>
+		<?php endif; ?>
 		<ul class="field">
 			<?php foreach ($instance['tags'] as $tag) : ?>
 				<?php $t = ucfirst(mb_strtolower(trim($tag))); ?>
 				<li>
 					<label>
-						<input type="checkbox" name="tags[]" value="<?php echo $tag ?>" />
-						 <?php echo $t ?>
+						<input type="<?php echo $instance['tagtype'] === 'multiple' ? 'checkbox' : 'radio' ?>"
+							name="tags[]" value="<?php echo $tag ?>">
+						<?php echo $t ?>
 					</label>
 				</li>
 			<?php endforeach; ?>
@@ -49,6 +52,9 @@
 	<?php endif; ?>
 
 	<p class="submit">
+		<?php if (!empty($instance['fixedtags'])) : ?>
+			<input type="hidden" name="tagsadditional" value="<?php echo $instance['fixedtags'] ?>">
+		<?php endif; ?>
 		<input class="submit" type="submit" value="<?php echo $instance['buttontext'] ?>">
 	</p>
 </form>


### PR DESCRIPTION
We now support creating a signup form that either has single (radio
inputs) or multiple (checkbox inputs) choices in the form. We also
support sending fixed tags with the subscription. Meaning that all
subscribers will receive this tag in MailMojo.

Resolves #2