### PR TITLE
Fix backwards compat bugs

### DIFF
--- a/src/mailmojo-plugin.php
+++ b/src/mailmojo-plugin.php
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 class MailMojoPlugin {
-	private $settings;
+	public $settings;
 
 	/*
 	 * The singleton instance

--- a/src/mailmojo-widget.php
+++ b/src/mailmojo-widget.php
@@ -115,6 +115,11 @@ class MailMojoWidget extends WP_Widget {
 		$instance = wp_parse_args($instance, $defaults);
 		$instance['incname'] = checked($instance['incname'], true, false);
 
+		// TODO: Remove when username is not present anymore.
+		if (empty($instance['subscribeurl']) && !empty($instance['listid'])) {
+			$instance['subscribeurl'] = $this->getSubscribeUrl($instance['listid']);
+		}
+
 		include('templates/widget-admin.php');
 	}
 
@@ -141,7 +146,7 @@ class MailMojoWidget extends WP_Widget {
 	 */
 	public function widget ($args, $instance) {
 		// TODO: Change to only check subscribe url when listid is removed
-		if (empty($instance['subscribeurl']) || empty($instance['listid'])) {
+		if (empty($instance['subscribeurl']) && empty($instance['listid'])) {
 			return '';
 		}
 
@@ -166,7 +171,7 @@ class MailMojoWidget extends WP_Widget {
 	 * @return string
 	 */
 	private function getSubscribeUrl ($listid) {
-		$username = $this->plugin->getUsername();
+		$username = $this->plugin->settings->getUsername();
 		return "https://{$username}.mailmojo.no/{$listid}/s";
 	}
 }


### PR DESCRIPTION
The code changes pretty much explains it self. The widget should render
even though no access token is added. We therefore need access to
username from settings class to build the subscribe URL.