### PR TITLE
Fix syntax error in PHP 5.4

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -3,7 +3,7 @@ Contributors: stianpr, asteinlein
 Tags: mailmojo, newsletter, newsletters, mailing list, signup, subscribe, widget, email, email marketing, email
 Requires at least: 4.0
 Tested up to: 4.7.1
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -39,7 +39,10 @@ This plugin requires the PHP curl extension.
 
 == Changelog ==
 
-= 1.0 =
+= 1.0.1 =
+* Fix syntax errors in PHP 5.4.
+
+= 1.0.0 =
 * Important: Requires PHP 5.4 or newer.
 * Use MailMojo API to support retrieval of email lists.
 * Support single vs multiple tag selection.

--- a/src/mailmojo-plugin.php
+++ b/src/mailmojo-plugin.php
@@ -46,7 +46,9 @@ class MailMojoPlugin {
 	 * Return the one and only singleton instance of this class.
 	 */
 	public static function getInstance () {
-		if (empty(self::$instance)) {
+		$obj = self::$instance;
+
+		if (empty($obj)) {
 			self::$instance = new MailMojoPlugin();
 		}
 
@@ -72,7 +74,8 @@ class MailMojoPlugin {
 	 * @return bool
 	 */
 	public function isActive () {
-		return !empty($this->settings->getAccessToken());
+		$token = $this->settings->getAccessToken();
+		return !empty($token);
 	}
 
 	/**

--- a/src/mailmojo-settings.php
+++ b/src/mailmojo-settings.php
@@ -45,7 +45,9 @@ class MailMojoSettings {
 	 * Return the one and only singleton instance of this class.
 	 */
 	public static function getInstance () {
-		if (empty(self::$instance)) {
+		$obj = self::$instance;
+
+		if (empty($obj)) {
 			self::$instance = new MailMojoSettings();
 		}
 

--- a/src/mailmojo.php
+++ b/src/mailmojo.php
@@ -5,7 +5,7 @@ Plugin URI: http://github.com/eliksir/MailMojo-WP-Widget
 Description: Adds a signup widget for a MailMojo mailing list to your WordPress site.
 Author: Eliksir AS
 Author URI: http://e5r.no
-Version: 1.0.0
+Version: 1.0.1
 */
 
 /*


### PR DESCRIPTION
There was still one syntax usage that is only supported from PHP 5.5+, giving `Fatal error: Can't use method return value in write context` in PHP 5.4. This is a simple fix of not passing a method return value directly into the `empty()` construct, but rather via a variable. Similarly we can't pass statically bound variables directly into `empty()`.

This fixes it and bumps version to 1.0.1 for a patch release.