### PR TITLE
Sort email lists by name for dropdown menu

### DIFF
--- a/src/mailmojo-widget.php
+++ b/src/mailmojo-widget.php
@@ -84,7 +84,11 @@ class MailMojoWidget extends WP_Widget {
 		if (self::$lists === null) {
 			try {
 				$api = new MailMojo\Api\ListsApi();
+
 				self::$lists = $api->getLists();
+				usort(self::$lists, function ($listA, $listB) {
+					return strcmp($listA->getName(), $listB->getName());
+				});
 			}
 			catch (MailMojo\ApiException $e) {
 				echo '<p>' . sprintf(


### PR DESCRIPTION
For ease of scanning through the list of email lists in the widget configuration dropdown, we now sort them by name.