### PR TITLE
Hide username settings field when token exists

### DIFF
--- a/src/mailmojo-settings.php
+++ b/src/mailmojo-settings.php
@@ -98,6 +98,8 @@ class MailMojoSettings {
 	 * Initiate the settings page.
 	 */
 	public function pageInit () {
+		$token = $this->getAccessToken();
+
 		register_setting(
 			self::GROUP_NAME,
 			'mailmojo_options',
@@ -120,13 +122,15 @@ class MailMojoSettings {
 		);
 
 		// TODO: Remove when username is not needed anymore.
-		add_settings_field(
-			'username',
-			'Username',
-			array($this, 'usernameField'),
-			'mailmojo-settings-admin',
-			'mailmojo_settings_id'
-		);
+		if (empty($token)) {
+			add_settings_field(
+				'username',
+				'Username',
+				array($this, 'usernameField'),
+				'mailmojo-settings-admin',
+				'mailmojo_settings_id'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
For legacy reasons we still display a (disabled) field showing the currently set MailMojo username in the MailMojo settings. This is for those who've used the WordPress plugin and widget before we switched to using the MailMojo API.

But once a user has upgraded and made use of an access token instead to use the MailMojo API, there's no reason to show the old username in a disabled field anymore.

Instead of complicating with a stored state indicating an access token has been used, we simply hide the username field if the access token setting currently has a value.