### PR TITLE
Avoid using `finally` syntax from PHP 5.5.0

### DIFF
--- a/src/mailmojo-settings.php
+++ b/src/mailmojo-settings.php
@@ -100,9 +100,8 @@ class MailMojoSettings {
 		catch (MailMojo\ApiException $e) {
 			$isValid = false;
 		}
-		finally {
-			$apiConfig->setAccessToken($existingToken);
-		}
+
+		$apiConfig->setAccessToken($existingToken);
 
 		return $isValid;
 	}


### PR DESCRIPTION
We strive for compatibility with PHP 5.4 and higher. However in 5e0fde064275aaeaaa64ac28c3274e640a5fba21 we made use of the `finally` syntax, which wasn't introduced in PHP until version 5.5.0.

This simply removes the usage of `finally` to be compatible with PHP 5.4.0 again.