### PR TITLE
Support PHP 7.2 and WordPress 5

### DIFF
--- a/src/mailmojo-plugin.php
+++ b/src/mailmojo-plugin.php
@@ -94,9 +94,9 @@ class MailMojoPlugin {
 	 * Inits the MailMojo widget.
 	 */
 	public function initWidget () {
-		add_action('widgets_init', create_function('',
-			'return register_widget("MailMojoWidget");')
-		);
+		add_action('widgets_init', function () {
+			return register_widget('MailMojoWidget');
+		});
 	}
 
 	/**

--- a/src/mailmojo-settings.php
+++ b/src/mailmojo-settings.php
@@ -21,7 +21,7 @@ class MailMojoSettings {
 	const MENU_SLUG = 'mailmojo-widget';
 	const MENU_TITLE = 'MailMojo';
 	const PAGE_TITLE = 'MailMojo';
-	const MM_INTEGRATIONS_URL = 'https://v2.mailmojo.no/account/integrations/wordpress/';
+	const MM_INTEGRATIONS_URL = 'https://v3.mailmojo.no/integrations/wordpress/';
 
 	private $options;
 	private $plugin;

--- a/src/mailmojo.php
+++ b/src/mailmojo.php
@@ -5,7 +5,7 @@ Plugin URI: http://github.com/eliksir/MailMojo-WP-Widget
 Description: Adds a signup widget for a MailMojo mailing list to your WordPress site.
 Author: Eliksir AS
 Author URI: http://e5r.no
-Version: 1.0.3
+Version: 1.0.4
 */
 
 /*

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -2,8 +2,8 @@
 Contributors: stianpr, asteinlein, fdanielsen
 Tags: mailmojo, newsletter, newsletters, mailing list, signup, subscribe, widget, email, email marketing, email
 Requires at least: 4.0
-Tested up to: 4.7.1
-Stable tag: 1.0.3
+Tested up to: 5.0.0
+Stable tag: 1.0.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -38,6 +38,11 @@ This plugin requires the PHP curl extension.
 2. Customize the widget with your choices.
 
 == Changelog ==
+
+= 1.0.4 =
+* Fix compatibility with PHP 7.2.
+* Fix link to MailMojo integrations page with token.
+* Verify compatibility with WordPress 5.
 
 = 1.0.3 =
 * Fix syntax errors in PHP 5.4.


### PR DESCRIPTION
Includes a fix for PHP 7.2 compatibility, even more important now that PHP 5.x will be completely EoL as of January 1st 2019 and more and more move to PHP 7.2.

While fixing, the plugin and widget have also been tested with WordPress 5, letting us ensure people it does work up to this new version as well.